### PR TITLE
Adding serializers for articles response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 4.1'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rack-cors', require: 'rack/cors'
+gem 'active_model_serializers'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.0.2.1)
       activesupport (= 6.0.2.1)
       globalid (>= 0.3.6)
@@ -60,6 +65,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.1)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
     coveralls (0.8.23)
@@ -83,6 +90,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
+    jsonapi-renderer (0.2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -203,6 +211,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   bootsnap (>= 1.4.2)
   coveralls
   factory_bot_rails

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -2,12 +2,12 @@ class Api::V1::ArticlesController < ApplicationController
   
   def index
     articles = Article.all
-    render json: { articles: articles },status: 200
+    render json: articles, each_serializer: ArticlesIndexSerializer
   end
 
   def show
     article = Article.find(params[:id])
-    render json: article
+    render json: article, serializer: ArticlesShowSerializer
   end
   
   def create

--- a/app/serializers/articles_index_serializer.rb
+++ b/app/serializers/articles_index_serializer.rb
@@ -1,0 +1,3 @@
+class ArticlesIndexSerializer < ActiveModel::Serializer
+  attributes :id, :title, :snippet
+end

--- a/app/serializers/articles_show_serializer.rb
+++ b/app/serializers/articles_show_serializer.rb
@@ -1,0 +1,3 @@
+class ArticlesShowSerializer < ActiveModel::Serializer
+  attributes :id, :title, :snippet, :content
+end

--- a/config/initializers/ams.rb
+++ b/config/initializers/ams.rb
@@ -1,0 +1,1 @@
+ActiveModelSerializers.config.adapter = :json

--- a/spec/requests/api/v1/articles_are_stored_in_index_list_spec.rb
+++ b/spec/requests/api/v1/articles_are_stored_in_index_list_spec.rb
@@ -23,9 +23,5 @@ describe 'GET /articles', type: :request do
     it 'checks if snippet is correct' do
       expect(JSON.parse(response.body)["articles"].first["snippet"]).to eq "Is space the next place?"
     end
-
-    it 'checks if content is correct' do
-      expect(JSON.parse(response.body)["articles"].first["content"]).to eq "Lau has become the president of space."
-    end
   end
 end

--- a/spec/requests/api/v1/visitor_can_see_specific_article_spec.rb
+++ b/spec/requests/api/v1/visitor_can_see_specific_article_spec.rb
@@ -10,15 +10,16 @@ RSpec.describe Api::V1::ArticlesController, type: :request do
     end
 
     it 'should return article title' do
-      expect(response_json['title']).to eq 'NOSPACE'
+      binding.pry
+      expect(response_json['article']['title']).to eq 'NOSPACE'
     end
 
     it 'should return article snippet' do
-      expect(response_json['snippet']).to eq 'You thought you liked space'
+      expect(response_json['article']['snippet']).to eq 'You thought you liked space'
     end
 
     it 'should return article content' do
-      expect(response_json['content']).to eq 'NOSPACE is where you want to be'
+      expect(response_json['article']['content']).to eq 'NOSPACE is where you want to be'
     end
   end
 end

--- a/spec/requests/api/v1/visitor_can_see_specific_article_spec.rb
+++ b/spec/requests/api/v1/visitor_can_see_specific_article_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe Api::V1::ArticlesController, type: :request do
     end
 
     it 'should return article title' do
-      binding.pry
       expect(response_json['article']['title']).to eq 'NOSPACE'
     end
 


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171983519)
## Changes proposed in this pull request:
* Adds serializer for index methods response
* Adds serializer for show methods response
## What I have learned working on this feature:
* More about serializers and sanitising the response
## Packages/Gems added
- active_model_serializers