### PR TITLE
API provides that visitor can select article by category

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -22,6 +22,6 @@ class Api::V1::ArticlesController < ApplicationController
   private
   
   def article_params
-    params.require(:article).permit(:title, :snippet, :content)
+    params.require(:article).permit(:title, :snippet, :content, :category)
   end
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,3 +1,4 @@
 class Article < ApplicationRecord
-  validates_presence_of :title, :snippet, :content
+  validates_presence_of :title, :snippet, :content, :category
+  enum category: [:latest_news, :tech, :sports, :politics, :culture]
 end

--- a/app/serializers/articles_index_serializer.rb
+++ b/app/serializers/articles_index_serializer.rb
@@ -1,3 +1,3 @@
 class ArticlesIndexSerializer < ActiveModel::Serializer
-  attributes :id, :title, :snippet
+  attributes :id, :title, :snippet, :category
 end

--- a/app/serializers/articles_show_serializer.rb
+++ b/app/serializers/articles_show_serializer.rb
@@ -1,3 +1,3 @@
 class ArticlesShowSerializer < ActiveModel::Serializer
-  attributes :id, :title, :snippet, :content
+  attributes :id, :title, :snippet, :content, :category
 end

--- a/db/migrate/20200326125544_add_category_to_article.rb
+++ b/db/migrate/20200326125544_add_category_to_article.rb
@@ -1,0 +1,5 @@
+class AddCategoryToArticle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :category, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_21_094716) do
+ActiveRecord::Schema.define(version: 2020_03_26_125544) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_03_21_094716) do
     t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "category"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -17,8 +17,8 @@ ActiveRecord::Schema.define(version: 2020_03_26_125544) do
 
   create_table "articles", force: :cascade do |t|
     t.string "title"
-    t.text "snippet"
     t.text "content"
+    t.text "snippet"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "category"

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     title { "SPACE" }
     snippet { "Is space the next place?" }
     content { "Lau has become the president of space." }
+    category { "tech" }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,12 +4,14 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column :title }
     it { is_expected.to have_db_column :snippet}
     it { is_expected.to have_db_column :content}
+    it { is_expected.to have_db_column :category}
   end
   
   describe 'Validations' do
     it { is_expected.to validate_presence_of :title }
     it { is_expected.to validate_presence_of :snippet }
     it { is_expected.to validate_presence_of :content}
+    it { is_expected.to validate_presence_of :category}
   end
   
   describe 'Factory' do

--- a/spec/requests/api/v1/articles_are_stored_in_index_list_spec.rb
+++ b/spec/requests/api/v1/articles_are_stored_in_index_list_spec.rb
@@ -2,7 +2,7 @@ describe 'GET /articles', type: :request do
   describe'successfull' do
     
     let!(:articles) {create(:article)}
-    let!(:articles2) {create(:article, title: 'NOSPACE', snippet: "You thought you liked space", content: "NOSPACE is where you want to be")}
+    let!(:articles2) {create(:article, title: 'NOSPACE', snippet: "You thought you liked space", content: "NOSPACE is where you want to be", category: "tech")}
     
     before do
       get '/api/v1/articles'

--- a/spec/requests/api/v1/articles_can_be_created_spec.rb
+++ b/spec/requests/api/v1/articles_can_be_created_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe 'POST /article', type: :request do
       post '/api/v1/articles',
       params: {
         article: {
-          title: "No more room in space",
-          snippet: "Its all gone, sorry",
-          content: "Govenor says this aint good",
-          category: "tech"
+          title: 'No more room in space',
+          snippet: 'Its all gone, sorry',
+          content: 'Govenor says this aint good',
+          category: 'tech'
         }
       }
     end
@@ -17,19 +17,19 @@ RSpec.describe 'POST /article', type: :request do
     end
 
     it 'displays correct title' do
-      expect(response.request.params['article']['title']).to eq "No more room in space"
+      expect(response.request.params['article']['title']).to eq 'No more room in space'
     end
 
     it 'displays correct snippet' do
-      expect(response.request.params['article']['snippet']).to eq "Its all gone, sorry"
+      expect(response.request.params['article']['snippet']).to eq 'Its all gone, sorry'
     end
 
     it 'displays correct content' do
-      expect(response.request.params['article']['content']).to eq "Govenor says this aint good"
+      expect(response.request.params['article']['content']).to eq 'Govenor says this aint good'
     end
 
     it 'displays correct category' do
-      expect(response.request.params['article']['category']).to eq "tech"
+      expect(response.request.params['article']['category']).to eq 'tech'
     end
 
   end
@@ -40,9 +40,9 @@ RSpec.describe 'POST /article', type: :request do
         params: {
           article: {
           title: '',
-          snippet: "this is text",
-          content: "content text",
-          category: "tech"
+          snippet: 'this is text',
+          content: 'content text',
+          category: 'tech'
           }
         }
     end
@@ -60,10 +60,10 @@ RSpec.describe 'POST /article', type: :request do
       post '/api/v1/articles',
       params: { 
         article: {
-          title: "Cool title",
-          snippet: "",
-          content: "content text",
-          category: "tech"
+          title: 'Cool title',
+          snippet: '',
+          content: 'content text',
+          category: 'tech'
         }
       }
     end
@@ -82,10 +82,10 @@ RSpec.describe 'POST /article', type: :request do
       post '/api/v1/articles',
       params: { 
         article: {
-          title: "Yes a title",
-          snippet: "this is text",
-          content: "",
-          category: "tech"
+          title: 'Yes a title',
+          snippet: 'this is text',
+          content: '',
+          category: 'tech'
         }
       }
     end
@@ -99,16 +99,15 @@ RSpec.describe 'POST /article', type: :request do
     end
   end
 
-
   describe 'sad path' do
     before do
       post '/api/v1/articles',
       params: { 
         article: {
-          title: "Yes a title",
-          snippet: "this is text",
-          content: "content text",
-          category: ""
+          title: 'Yes a title',
+          snippet: 'this is text',
+          content: 'content text',
+          category: ''
         }
       }
     end

--- a/spec/requests/api/v1/articles_can_be_created_spec.rb
+++ b/spec/requests/api/v1/articles_can_be_created_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe 'POST /article', type: :request do
         article: {
           title: "No more room in space",
           snippet: "Its all gone, sorry",
-          content: "Govenor says this aint good"
+          content: "Govenor says this aint good",
+          category: "tech"
         }
       }
     end
@@ -22,9 +23,15 @@ RSpec.describe 'POST /article', type: :request do
     it 'displays correct snippet' do
       expect(response.request.params['article']['snippet']).to eq "Its all gone, sorry"
     end
+
     it 'displays correct content' do
       expect(response.request.params['article']['content']).to eq "Govenor says this aint good"
     end
+
+    it 'displays correct category' do
+      expect(response.request.params['article']['category']).to eq "tech"
+    end
+
   end
 
   describe 'sad path' do
@@ -34,7 +41,8 @@ RSpec.describe 'POST /article', type: :request do
           article: {
           title: '',
           snippet: "this is text",
-          content: "content text"
+          content: "content text",
+          category: "tech"
           }
         }
     end
@@ -54,7 +62,8 @@ RSpec.describe 'POST /article', type: :request do
         article: {
           title: "Cool title",
           snippet: "",
-          content: "content text"
+          content: "content text",
+          category: "tech"
         }
       }
     end
@@ -75,7 +84,8 @@ RSpec.describe 'POST /article', type: :request do
         article: {
           title: "Yes a title",
           snippet: "this is text",
-          content: ""
+          content: "",
+          category: "tech"
         }
       }
     end
@@ -86,6 +96,29 @@ RSpec.describe 'POST /article', type: :request do
     
     it 'displays error message on empty content' do
       expect(JSON.parse(response.body)['message']).to eq "Content can't be blank"
+    end
+  end
+
+
+  describe 'sad path' do
+    before do
+      post '/api/v1/articles',
+      params: { 
+        article: {
+          title: "Yes a title",
+          snippet: "this is text",
+          content: "content text",
+          category: ""
+        }
+      }
+    end
+
+    it 'displays error of incomplete article' do
+      expect(response.status).to eq 422
+    end
+    
+    it 'displays error message on empty category' do
+      expect(JSON.parse(response.body)['message']).to eq "Category can't be blank"
     end
   end
 end

--- a/spec/requests/api/v1/visitor_can_see_specific_article_spec.rb
+++ b/spec/requests/api/v1/visitor_can_see_specific_article_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Api::V1::ArticlesController, type: :request do
     end
 
     it 'should return article category' do
-      expect(reponse_json['article']['category']).to eq 'tech'
+      expect(response_json['article']['category']).to eq 'tech'
     end 
   end
 end

--- a/spec/requests/api/v1/visitor_can_see_specific_article_spec.rb
+++ b/spec/requests/api/v1/visitor_can_see_specific_article_spec.rb
@@ -20,5 +20,9 @@ RSpec.describe Api::V1::ArticlesController, type: :request do
     it 'should return article content' do
       expect(response_json['article']['content']).to eq 'NOSPACE is where you want to be'
     end
+
+    it 'should return article category' do
+      expect(reponse_json['article']['category']).to eq 'tech'
+    end 
   end
 end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171984822)
## Changes proposed in this pull request:
* Adds category attribute to article model as enum
* Updates the factorybot and the specs to tests the new attribute
## What I have learned working on this feature:
* How to use an enum attribute