### PR TITLE
API provides restrictions on premium articles for visitors

### DIFF
--- a/db/migrate/20200328181213_add_premium_to_article.rb
+++ b/db/migrate/20200328181213_add_premium_to_article.rb
@@ -1,0 +1,5 @@
+class AddPremiumToArticle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :premium, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_26_125544) do
+ActiveRecord::Schema.define(version: 2020_03_28_181213) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "articles", force: :cascade do |t|
     t.string "title"
-    t.text "content"
     t.text "snippet"
+    t.text "content"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "category"
+    t.boolean "premium", default: true
   end
 
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column :snippet}
     it { is_expected.to have_db_column :content}
     it { is_expected.to have_db_column :category}
+    it { is_expected.to have_db_column :premium}
   end
   
   describe 'Validations' do


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/171817648)
## Changes proposed in this pull request:
* Adds attribute premium to articles and setting it as a boolean with default value true
## What I have learned working on this feature:
* Refreshed knowledge about adding attributes to an already existing table 
