### PR TITLE
Api provides that editor can view articles

### DIFF
--- a/app/controllers/api/v1/admin_controller.rb
+++ b/app/controllers/api/v1/admin_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::AdminController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    if current_user.role == "editor"
+      articles = Article.where(published: false)
+      render json: articles, each_serializer: ArticlesShowSerializer
+    else
+      render json: {
+               message: 'You are not authenticated to view unpublished articles'
+             },
+             status: 401
+    end
+  end
+end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::ArticlesController < ApplicationController
   before_action :authenticate_user!, only: %i[create]
 
   def index
-    articles = Article.all
+    articles = Article.where(published: true)
     render json: articles, each_serializer: ArticlesIndexSerializer
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,5 +6,5 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
   include DeviseTokenAuth::Concerns::User
   validates_presence_of :role
-  enum role: [ :reg_user, :subscriber, :journalist ]
+  enum role: [ :reg_user, :subscriber, :journalist, :editor ]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :articles, only:[:index, :create, :show]
       resources :subscriptions, only:[:create]
+      resources :admin, only:[:index]
     end
   end
 end

--- a/db/migrate/20200403082021_add_published_to_article.rb
+++ b/db/migrate/20200403082021_add_published_to_article.rb
@@ -1,0 +1,5 @@
+class AddPublishedToArticle < ActiveRecord::Migration[6.0]
+  def change
+    add_column :articles, :published, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_02_074922) do
+ActiveRecord::Schema.define(version: 2020_04_03_082021) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 2020_04_02_074922) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "category"
     t.boolean "premium", default: true
+    t.boolean "published", default: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
     snippet { "Is space the next place?" }
     content { "Lau has become the president of space." }
     category { "tech" }
+    premium { true }
+    published { true }
     trait :with_image do
       image { fixture_file_upload(Rails.root.join('spec', 'support', 'assets', 'test-image.png'), 'image/png') }
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,14 +1,17 @@
 FactoryBot.define do
   factory :user do
     email { "user#{rand(1...9999)}@mail.com" }
-    password { 'password' }
-    password_confirmation { 'password' }
-    role { 'reg_user' }
+    password { "password" }
+    password_confirmation { "password" }
+    role { "reg_user" }
     factory :subscriber do
-      role { 'subscriber' }
+      role { "subscriber" }
     end
     factory :journalist do
-      role { 'journalist' }
+      role { "journalist" }
+    end
+    factory :editor do
+      role { "editor" }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe User, type: :model do
   it 'should have valid Factory' do
     expect(create(:journalist)).to be_valid
   end
+
+  it 'should have valid Factory' do
+    expect(create(:editor)).to be_valid
+  end
+  
   describe 'Database table' do
     it { is_expected.to have_db_column :encrypted_password }
     it { is_expected.to have_db_column :email }

--- a/spec/requests/api/v1/articles_can_be_created_spec.rb
+++ b/spec/requests/api/v1/articles_can_be_created_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'POST /article', type: :request do
       data: 'GHJKFNKSJHFUDHFdnfkdjfjkshuhFNLNKLFDFJLkjksldjflkgdmsk248273rendlksfn',
       extension: 'jpg'
     }
-end
+  end
 
   describe 'successfull' do
     before do

--- a/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
+++ b/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
@@ -49,6 +49,27 @@ RSpec.describe "GET /articles", type: :request do
     ).to eq 2
   end
 
+  it "should return article title" do
+    expect(response_json["articles"][0]["title"]).to eq "NOSPACE"
+  end
+
+  it "should return article snippet" do
+    expect(
+      response_json["articles"][0]["snippet"]
+
+    ).to eq "You thought you liked space"
+  end
+
+  it "should return article content" do
+    expect(
+      response_json["articles"][0]["content"]
+    ).to eq "NOSPACE is where you want to be"
+  end
+
+  it "should return article category" do
+    expect(response_json["articles"][0]["category"]).to eq "tech"
+  end
+
   describe "journalist can not view unpublished articles" do
     before { get "/api/v1/admin", headers: journalist_headers }
 
@@ -57,26 +78,9 @@ RSpec.describe "GET /articles", type: :request do
     end
 
     it "journalist should not see articles" do
-       
       expect(
         response_json["message"]
       ).to eq "You are not authenticated to view unpublished articles"
     end
   end
-
-  # it "editor should see all published articles" do
-  #   expect(
-  #     response_json["article"].count
-  #   ).to eq 2
-  # end
-
-  # it "displays correct content" do
-  #   expect(
-  #     response.request.params["article"]["content"]
-  #   ).to eq "Govenor says this aint good"
-  # end
-
-  # it "displays correct category" do
-  #   expect(response.request.params["article"]["category"]).to eq "tech"
-  # end
 end

--- a/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
+++ b/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
@@ -21,23 +21,23 @@ RSpec.describe "GET /articles", type: :request do
       content: "NOSPACE is where you want to be",
       category: "tech",
       premium: true,
-      published: false
+      published: false,
     )
   end
-    let!(:articles3) do
-      create(
-        :article,
-        :with_image,
-        title: "SPACE",
-        snippet: "You thought you did not liked space",
-        content: "SPACE is where you want to be",
-        category: "sports",
-        premium: true,
-        published: false
-      )
+  let!(:articles3) do
+    create(
+      :article,
+      :with_image,
+      title: "SPACE",
+      snippet: "You thought you did not liked space",
+      content: "SPACE is where you want to be",
+      category: "sports",
+      premium: true,
+      published: false,
+    )
   end
 
-  before { get '/api/v1/admin', headers: editor_headers }
+  before { get "/api/v1/admin", headers: editor_headers }
 
   it "returns 200 status" do
     expect(response.status).to eq 200
@@ -45,7 +45,23 @@ RSpec.describe "GET /articles", type: :request do
 
   it "editor should see all unpublished articles" do
     expect(
-      response_json["articles"].count).to eq 2
+      response_json["articles"].count
+    ).to eq 2
+  end
+
+  describe "journalist can not view unpublished articles" do
+    before { get "/api/v1/admin", headers: journalist_headers }
+
+    it "returns 401 status" do
+      expect(response.status).to eq 401
+    end
+
+    it "journalist should not see articles" do
+       
+      expect(
+        response_json["message"]
+      ).to eq "You are not authenticated to view unpublished articles"
+    end
   end
 
   # it "editor should see all published articles" do

--- a/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
+++ b/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe "GET /articles", type: :request do
     expect(response_json["articles"].first["category"]).to eq "tech"
   end
 
+  it "should return premium to be true" do
+    expect(response_json["articles"].first["premium"]).to eq true
+  end
+
   describe "journalist can not view unpublished articles" do
     before { get "/api/v1/admin", headers: journalist_headers }
 

--- a/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
+++ b/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
@@ -20,32 +20,47 @@ RSpec.describe "GET /articles", type: :request do
       snippet: "You thought you liked space",
       content: "NOSPACE is where you want to be",
       category: "tech",
+      premium: true,
+      published: false
     )
   end
+    let!(:articles3) do
+      create(
+        :article,
+        :with_image,
+        title: "SPACE",
+        snippet: "You thought you did not liked space",
+        content: "SPACE is where you want to be",
+        category: "sports",
+        premium: true,
+        published: false
+      )
+  end
+
+  before { get '/api/v1/articles' }
 
   it "returns 200 status" do
     expect(response.status).to eq 200
   end
 
-  it "displays correct title" do
+  it "editor should see all published articles" do
     expect(
-      response.request.params["article"]["title"]
-    ).to eq "No more room in space"
+      response_json["articles"].count).to eq 2
   end
 
-  it "displays correct snippet" do
-    expect(
-      response.request.params["article"]["snippet"]
-    ).to eq "Its all gone, sorry"
-  end
+  # it "editor should see all published articles" do
+  #   expect(
+  #     response_json["article"].count
+  #   ).to eq 2
+  # end
 
-  it "displays correct content" do
-    expect(
-      response.request.params["article"]["content"]
-    ).to eq "Govenor says this aint good"
-  end
+  # it "displays correct content" do
+  #   expect(
+  #     response.request.params["article"]["content"]
+  #   ).to eq "Govenor says this aint good"
+  # end
 
-  it "displays correct category" do
-    expect(response.request.params["article"]["category"]).to eq "tech"
-  end
+  # it "displays correct category" do
+  #   expect(response.request.params["article"]["category"]).to eq "tech"
+  # end
 end

--- a/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
+++ b/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe "GET /articles", type: :request do
       )
   end
 
-  before { get '/api/v1/articles' }
+  before { get '/api/v1/admin', headers: editor_headers }
 
   it "returns 200 status" do
     expect(response.status).to eq 200
   end
 
-  it "editor should see all published articles" do
+  it "editor should see all unpublished articles" do
     expect(
       response_json["articles"].count).to eq 2
   end

--- a/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
+++ b/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe "GET /articles", type: :request do
+  let(:editor) { create(:user, role: "editor") }
+  let(:editor_credentials) { editor.create_new_auth_token }
+  let(:editor_headers) do
+    { HTTP_ACCEPT: "application/json" }.merge!(editor_credentials)
+  end
+
+  let(:journalist) { create(:user, role: "journalist") }
+  let(:journalist_credentials) { journalist.create_new_auth_token }
+  let(:journalist_headers) do
+    { HTTP_ACCEPT: "application/json" }.merge!(journalist_credentials)
+  end
+
+  let!(:articles) { create(:article) }
+  let!(:articles2) do
+    create(
+      :article,
+      :with_image,
+      title: "NOSPACE",
+      snippet: "You thought you liked space",
+      content: "NOSPACE is where you want to be",
+      category: "tech",
+    )
+  end
+
+  it "returns 200 status" do
+    expect(response.status).to eq 200
+  end
+
+  it "displays correct title" do
+    expect(
+      response.request.params["article"]["title"]
+    ).to eq "No more room in space"
+  end
+
+  it "displays correct snippet" do
+    expect(
+      response.request.params["article"]["snippet"]
+    ).to eq "Its all gone, sorry"
+  end
+
+  it "displays correct content" do
+    expect(
+      response.request.params["article"]["content"]
+    ).to eq "Govenor says this aint good"
+  end
+
+  it "displays correct category" do
+    expect(response.request.params["article"]["category"]).to eq "tech"
+  end
+end

--- a/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
+++ b/spec/requests/api/v1/editor_can_view_a_list_of_unpublished_articles_spec.rb
@@ -50,24 +50,24 @@ RSpec.describe "GET /articles", type: :request do
   end
 
   it "should return article title" do
-    expect(response_json["articles"][0]["title"]).to eq "NOSPACE"
+    expect(response_json["articles"].first["title"]).to eq "NOSPACE"
   end
 
   it "should return article snippet" do
     expect(
-      response_json["articles"][0]["snippet"]
+      response_json["articles"].first["snippet"]
 
     ).to eq "You thought you liked space"
   end
 
   it "should return article content" do
     expect(
-      response_json["articles"][0]["content"]
+      response_json["articles"].first["content"]
     ).to eq "NOSPACE is where you want to be"
   end
 
   it "should return article category" do
-    expect(response_json["articles"][0]["category"]).to eq "tech"
+    expect(response_json["articles"].first["category"]).to eq "tech"
   end
 
   describe "journalist can not view unpublished articles" do


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/172126876)

## Changes proposed in this pull request:
* Adding admin controller with index action for only editors
* Testing happy and sad path for the authentication of that action
* Adding column published as a boolean to the article model
* Restricting the index for the visitor client to only view published articles

## What I have learned working on this feature:
* How to make use of controllers for calling the 'same' methods with different authentications 
