### PR TITLE
API provides that Editor can publish articles

### DIFF
--- a/app/controllers/api/v1/admin_controller.rb
+++ b/app/controllers/api/v1/admin_controller.rb
@@ -29,14 +29,9 @@ class Api::V1::AdminController < ApplicationController
   end
 
   def update
-    if current_user.role == "editor"
-      article = Article.find(params[:id])
-      if article.update(article_params)
-        render json: { message: "Article is published" }
-      else
-        render json: { message: "You are not authenticated to publish an article" },
-               status: 401
-      end
+    article = Article.find(params[:id])
+    if current_user.role == "editor" && article.update(article_params)
+      render json: { message: "Article is published" }
     else
       render json: { message: "You are not authenticated to publish an article" },
              status: 401

--- a/app/controllers/api/v1/admin_controller.rb
+++ b/app/controllers/api/v1/admin_controller.rb
@@ -30,8 +30,30 @@ class Api::V1::AdminController < ApplicationController
   end
 
   def update
-    render json: { message: "Article is published"}
+    @article = Article.find(params[:id])
+    if @article.update(article_params)
+      redirect_to @article, :notice => "Article was successfully edited"
+    else
+      render 'edit'
+    end
   end
+  
+  # def update
+  #   if current_user.role == 'editor'
+  #     article = Article.update(article_params)
+  #     if article.persisted? && attach_image(article)
+      
+  #       render json: { message: "Article is published"}
+  #     else
+  #       render json: { message: article.errors.full_messages.to_sentence },
+  #              status: 422
+  #     end
+  #   else
+  #     render json: { message: 'You are not authenticated to publish an article' },
+  #     status: 401
+  #   end
+    
+  # end
 
   private
 

--- a/app/controllers/api/v1/admin_controller.rb
+++ b/app/controllers/api/v1/admin_controller.rb
@@ -29,6 +29,10 @@ class Api::V1::AdminController < ApplicationController
     end
   end
 
+  def update
+    render json: { message: "Article is published"}
+  end
+
   private
 
   def article_params

--- a/app/controllers/api/v1/admin_controller.rb
+++ b/app/controllers/api/v1/admin_controller.rb
@@ -7,65 +7,53 @@ class Api::V1::AdminController < ApplicationController
       render json: articles, each_serializer: ArticlesShowSerializer
     else
       render json: {
-               message: 'You are not authenticated to view unpublished articles'
+               message: "You are not authenticated to view unpublished articles",
              },
              status: 401
     end
   end
 
   def create
-    if current_user.role == 'journalist'
+    if current_user.role == "journalist"
       article = Article.create(article_params)
       if article.persisted? && attach_image(article)
-      
-        render json: { message: 'Your article was saved' }
+        render json: { message: "Your article was saved" }
       else
         render json: { message: article.errors.full_messages.to_sentence },
                status: 422
       end
     else
-      render json: { message: 'You are not authenticated to create an article' },
-      status: 401
+      render json: { message: "You are not authenticated to create an article" },
+             status: 401
     end
   end
 
   def update
-    @article = Article.find(params[:id])
-    if @article.update(article_params)
-      redirect_to @article, :notice => "Article was successfully edited"
+    if current_user.role == "editor"
+      article = Article.find(params[:id])
+      if article.update(article_params)
+        render json: { message: "Article is published" }
+      else
+        render json: { message: "You are not authenticated to publish an article" },
+               status: 401
+      end
     else
-      render 'edit'
+      render json: { message: "You are not authenticated to publish an article" },
+             status: 401
     end
   end
-  
-  # def update
-  #   if current_user.role == 'editor'
-  #     article = Article.update(article_params)
-  #     if article.persisted? && attach_image(article)
-      
-  #       render json: { message: "Article is published"}
-  #     else
-  #       render json: { message: article.errors.full_messages.to_sentence },
-  #              status: 422
-  #     end
-  #   else
-  #     render json: { message: 'You are not authenticated to publish an article' },
-  #     status: 401
-  #   end
-    
-  # end
 
   private
 
   def article_params
-    params.require(:article).permit(:title, :snippet, :content, :category, :premium)
+    params.require(:article).permit(:title, :snippet, :content, :category, :premium, :published)
   end
 
   def attach_image(article)
-    params_image = params['article']['image']
+    params_image = params["article"]["image"]
 
     if params_image.present?
-    DecodeService.attach_image(params_image, article.image)
+      DecodeService.attach_image(params_image, article.image)
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :articles, only:[:index, :show]
       resources :subscriptions, only:[:create]
-      resources :admin, only:[:index, :create]
+      resources :admin, only:[:index, :create, :update]
       resources :sessions, only:[:create ]
     end
   end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Article, type: :model do
     it { is_expected.to have_db_column :content}
     it { is_expected.to have_db_column :category}
     it { is_expected.to have_db_column :premium}
+    it { is_expected.to have_db_column :published}
   end
   
   describe 'Validations' do
@@ -13,6 +14,9 @@ RSpec.describe Article, type: :model do
     it { is_expected.to validate_presence_of :snippet }
     it { is_expected.to validate_presence_of :content}
     it { is_expected.to validate_presence_of :category}
+    
+    
+    
   end
   
   describe 'Factory' do

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,26 +1,23 @@
 RSpec.describe Article, type: :model do
-  describe 'DB table' do
+  describe "DB table" do
     it { is_expected.to have_db_column :id }
     it { is_expected.to have_db_column :title }
-    it { is_expected.to have_db_column :snippet}
-    it { is_expected.to have_db_column :content}
-    it { is_expected.to have_db_column :category}
-    it { is_expected.to have_db_column :premium}
-    it { is_expected.to have_db_column :published}
+    it { is_expected.to have_db_column :snippet }
+    it { is_expected.to have_db_column :content }
+    it { is_expected.to have_db_column :category }
+    it { is_expected.to have_db_column :premium }
+    it { is_expected.to have_db_column :published }
   end
-  
-  describe 'Validations' do
+
+  describe "Validations" do
     it { is_expected.to validate_presence_of :title }
     it { is_expected.to validate_presence_of :snippet }
-    it { is_expected.to validate_presence_of :content}
-    it { is_expected.to validate_presence_of :category}
-    
-    
-    
+    it { is_expected.to validate_presence_of :content }
+    it { is_expected.to validate_presence_of :category }
   end
-  
-  describe 'Factory' do
-    it 'should have valid Factory' do
+
+  describe "Factory" do
+    it "should have valid Factory" do
       expect(FactoryBot.create(:article)).to be_valid
     end
   end

--- a/spec/requests/api/v1/editor_can_publish_articles_spec.rb
+++ b/spec/requests/api/v1/editor_can_publish_articles_spec.rb
@@ -24,18 +24,31 @@ RSpec.describe "PUT /articles", type: :request do
     )
   end
 
-  before { put "/api/v1/admin/#{Article.last.id}", params:  { article: { title: "SPACE", published: true }}, headers: editor_headers }
+  before { put "/api/v1/admin/#{Article.last.id}", params: { article: { published: true } }, headers: editor_headers }
 
   it "returns 200 status" do
     expect(response.status).to eq 200
   end
 
   it "should return a success message" do
-    expect(response_json["message"]
-    ).to eq "Article is published"
+    expect(response_json["message"]).to eq "Article is published"
   end
 
   it "editor can publish article" do
     expect(Article.last["published"]).to eq true
+  end
+
+  describe "journalist can not view unpublished articles" do
+    before { put "/api/v1/admin/#{Article.last.id}", params: { article: { published: true } }, headers: journalist_headers }
+
+    it "returns 401 status" do
+      expect(response.status).to eq 401
+    end
+
+    it "journalist should not be allowed to publish" do
+      expect(
+        response_json["message"]
+      ).to eq "You are not authenticated to publish an article"
+    end
   end
 end

--- a/spec/requests/api/v1/editor_can_publish_articles_spec.rb
+++ b/spec/requests/api/v1/editor_can_publish_articles_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe "PUT /articles", type: :request do
+  let(:editor) { create(:user, role: "editor") }
+  let(:editor_credentials) { editor.create_new_auth_token }
+  let(:editor_headers) do
+    { HTTP_ACCEPT: "application/json" }.merge!(editor_credentials)
+  end
+
+  let(:journalist) { create(:user, role: "journalist") }
+  let(:journalist_credentials) { journalist.create_new_auth_token }
+  let(:journalist_headers) do
+    { HTTP_ACCEPT: "application/json" }.merge!(journalist_credentials)
+  end
+
+  let!(:articles2) do
+    create(
+      :article,
+      :with_image,
+      title: "NOSPACE",
+      snippet: "You thought you liked space",
+      content: "NOSPACE is where you want to be",
+      category: "tech",
+      premium: true,
+      published: false,
+    )
+  end
+
+  before { put "/api/v1/admin/**", headers: editor_headers }
+
+  it "returns 200 status" do
+    expect(response.status).to eq 200
+  end
+
+  it "should return a success message" do
+    expect(response_json["message"]
+    ).to eq "Article is published"
+  end
+end

--- a/spec/requests/api/v1/editor_can_publish_articles_spec.rb
+++ b/spec/requests/api/v1/editor_can_publish_articles_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe "PUT /articles", type: :request do
     { HTTP_ACCEPT: "application/json" }.merge!(journalist_credentials)
   end
 
-  let!(:articles) { create(:article) }
   let!(:articles2) do
     create(
       :article,
@@ -24,20 +23,8 @@ RSpec.describe "PUT /articles", type: :request do
       published: false,
     )
   end
-  let!(:articles2) do
-    update(
-      :article,
-      :with_image,
-      title: "NOSPACE",
-      snippet: "You thought you liked space",
-      content: "NOSPACE is where you want to be",
-      category: "tech",
-      premium: true,
-      published: false,
-    )
-  end
 
-  before { put "/api/v1/admin/#{Article.last.id}", headers: editor_headers }
+  before { put "/api/v1/admin/#{Article.last.id}", params:  { article: { title: "SPACE", published: true }}, headers: editor_headers }
 
   it "returns 200 status" do
     expect(response.status).to eq 200
@@ -49,7 +36,6 @@ RSpec.describe "PUT /articles", type: :request do
   end
 
   it "editor can publish article" do
-    binding.pry
-    expect(response_json["articles"].first["published"]).to eq true
+    expect(Article.last["published"]).to eq true
   end
 end

--- a/spec/requests/api/v1/editor_can_publish_articles_spec.rb
+++ b/spec/requests/api/v1/editor_can_publish_articles_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "PUT /articles", type: :request do
     { HTTP_ACCEPT: "application/json" }.merge!(journalist_credentials)
   end
 
+  let!(:articles) { create(:article) }
   let!(:articles2) do
     create(
       :article,
@@ -23,8 +24,20 @@ RSpec.describe "PUT /articles", type: :request do
       published: false,
     )
   end
+  let!(:articles2) do
+    update(
+      :article,
+      :with_image,
+      title: "NOSPACE",
+      snippet: "You thought you liked space",
+      content: "NOSPACE is where you want to be",
+      category: "tech",
+      premium: true,
+      published: false,
+    )
+  end
 
-  before { put "/api/v1/admin/**", headers: editor_headers }
+  before { put "/api/v1/admin/#{Article.last.id}", headers: editor_headers }
 
   it "returns 200 status" do
     expect(response.status).to eq 200
@@ -33,5 +46,10 @@ RSpec.describe "PUT /articles", type: :request do
   it "should return a success message" do
     expect(response_json["message"]
     ).to eq "Article is published"
+  end
+
+  it "editor can publish article" do
+    binding.pry
+    expect(response_json["articles"].first["published"]).to eq true
   end
 end


### PR DESCRIPTION
# [PT Story](https://www.pivotaltracker.com/story/show/172126905)
```
As an editor,
In order to make sure that the articles have good standards
I would like only editors to be able to publish articles.
```
## Changes proposed in this pull request:
* Adds update article method to admin controller
* Configures update route for Admin Controller
* Tested that only editor can publish articles
## What I have learned working on this feature:
* Refreshed knowledge on update action
